### PR TITLE
Extend stackmap check to compare location offsets and constant values.

### DIFF
--- a/stack-metadata/utils/check_stackmaps.c
+++ b/stack-metadata/utils/check_stackmaps.c
@@ -102,7 +102,7 @@ ret_t check_stackmaps(bin *a, stack_map_section *sm_a, size_t num_sm_a,
 	char buf[BUF_SIZE];
 	size_t i, j, k, l, num_sm, num_records;
 	uint64_t func_a, func_b;
-	uint8_t flag_a, flag_b;
+	int32_t flag_a, flag_b;
 	uint32_t size_a, size_b;
 	GElf_Sym sym_a, sym_b;
 	const char *sym_a_name, *sym_b_name;
@@ -212,7 +212,7 @@ ret_t check_stackmaps(bin *a, stack_map_section *sm_a, size_t num_sm_a,
 					if(flag_a != flag_b)
 					{
 						snprintf(buf, BUF_SIZE, "%s: stackmap %lu, location %lu/%lu has "
-												"different size (%u vs. %u)",
+												"different size (%d vs. %d)",
 								 sym_a_name, sm_a[i].call_sites[j].id, k, l, flag_a,
 								 flag_b);
 						warn(buf);
@@ -224,7 +224,7 @@ ret_t check_stackmaps(bin *a, stack_map_section *sm_a, size_t num_sm_a,
 					if(flag_a != flag_b)
 					{
 						snprintf(buf, BUF_SIZE, "%s: stackmap %lu, location %lu/%lu has "
-												"mismatched pointer flag (%u vs. %u)",
+												"mismatched pointer flag (%d vs. %d)",
 								 sym_a_name, sm_a[i].call_sites[j].id, k, l, flag_a,
 								 flag_b);
 						warn(buf);
@@ -236,7 +236,7 @@ ret_t check_stackmaps(bin *a, stack_map_section *sm_a, size_t num_sm_a,
 					if(flag_a != flag_b)
 					{
 						snprintf(buf, BUF_SIZE, "%s: stackmap %lu, location %lu/%lu has "
-												"mismatched alloca flag (%u vs. %u)",
+												"mismatched alloca flag (%d vs. %d)",
 								 sym_a_name, sm_a[i].call_sites[j].id, k, l, flag_a,
 								 flag_b);
 						warn(buf);
@@ -250,7 +250,7 @@ ret_t check_stackmaps(bin *a, stack_map_section *sm_a, size_t num_sm_a,
 						if(size_a != size_b)
 						{
 							snprintf(buf, BUF_SIZE, "%s: stackmap %lu, location %lu/%lu has "
-													"different size (%u vs. %u)",
+													"different size (%d vs. %d)",
 									 sym_a_name, sm_a[i].call_sites[j].id, k, l,
 									 size_a, size_b);
 							warn(buf);
@@ -263,7 +263,19 @@ ret_t check_stackmaps(bin *a, stack_map_section *sm_a, size_t num_sm_a,
 					if(flag_a != flag_b)
 					{
 						snprintf(buf, BUF_SIZE, "%s: stackmap %lu, location %lu/%lu has "
-												"different location type (%u vs. %u)",
+												"different location type (%d vs. %d)",
+								 sym_a_name, sm_a[i].call_sites[j].id, k, l, flag_a,
+								 flag_b);
+						warn(buf);
+						ret = DIFFERENT_STACK_LAYOUT;
+					}
+
+					flag_a = sm_a[i].call_sites[j].locations[k].offset_or_constant;
+					flag_b = sm_b[i].call_sites[j].locations[l].offset_or_constant;
+					if(flag_a != flag_b)
+					{
+						snprintf(buf, BUF_SIZE, "%s: stackmap %lu, location %lu/%lu has "
+												"different location offset or  different constant (%d vs. %d)",
 								 sym_a_name, sm_a[i].call_sites[j].id, k, l, flag_a,
 								 flag_b);
 						warn(buf);


### PR DESCRIPTION
Closes #43.

Now, the tool catches differences like:

```
    Location: at register 6 + -12, is an alloca of size 4 byte(s)
```

and

```
    Location: at register 29 + -28, is an alloca of size 4 byte(s)
```

Where the offsets from the frame pointers are different.