### PR TITLE
Extend stackmaps check to narrow the comparison for only one given function

### DIFF
--- a/stack-metadata/utils/check_stackmaps.c
+++ b/stack-metadata/utils/check_stackmaps.c
@@ -96,8 +96,9 @@ static void parse_args(int argc, char **argv)
 
 /*
  * The goal of the checker is to print out as much non-matching information as
- * possible rather than to die on errors.  So, we'll iterate over everything
- * and print out where we find inconsistencies.
+ * possible rather than to die on errors.
+ * So, we'll iterate over everything and print out where we find inconsistencies.
+ * If `function_name` is given, we only check the callsites of this function.
  */
 ret_t check_stackmaps(bin *a, stack_map_section *sm_a, size_t num_sm_a,
 					  bin *b, stack_map_section *sm_b, size_t num_sm_b)
@@ -176,6 +177,14 @@ ret_t check_stackmaps(bin *a, stack_map_section *sm_a, size_t num_sm_a,
 			}
 			else
 			{
+				/*
+				 * If `func_name` is given as an argument, only check the function
+				 * record with that name.
+				 */
+				if (func_name && strcmp(sym_a_name, func_name) != 0)
+				{
+					continue;
+				}
 				/*
 				 * The raw location record count may be different, so count
 				 * non-duplicated records, i.e., ignore backing stack slot locations.


### PR DESCRIPTION
It would be useful to extend our tool so that it doesn't print a dump with all stack differences for two binaries, but only for a specific function. This is especially useful for large binaries like NPB.