### PR TITLE
Added `-sink-insts-to-avoid-spills` llc flag to workflow.

### DIFF
--- a/layout/common/common.mk
+++ b/layout/common/common.mk
@@ -45,7 +45,7 @@ override LLC_FLAGS 	+= -relocation-model=pic --trap-unreachable -optimize-regall
 # Callsite-related
 override LLC_FLAGS  += -disable-block-align --mc-relax-all
 # Custom
-override LLC_FLAGS  += -disable-x86-frame-obj-order -aarch64-csr-alignment=8 -simplify-regalloc -disable-lsr-solver
+override LLC_FLAGS  += -disable-x86-frame-obj-order -aarch64-csr-alignment=8 -simplify-regalloc -disable-lsr-solver -sink-insts-to-avoid-spills
 
 HET_CFLAGS 	:= $(CFLAGS) #-fno-common -ftls-model=initial-exec
 


### PR DESCRIPTION
In simple loops where we need to call a function and pass by reference,
the X86 backend uses a LEA instruction to get the reference, which is hoisted
outside of the loop. This causes greater register pressure and might
lead to a spill, that AArch64 will not have.

Thus, we add the llc flag to sink the LEA instruction back into the
loop, since it causes greater register pressure. Maybe a temporary fix.

Closes #30