### PR TITLE
Fix flag in makefile causing data layout mismatch.

### DIFF
--- a/layout/common/common.mk
+++ b/layout/common/common.mk
@@ -36,7 +36,7 @@ LLC 	:= $(LLVM_TOOLCHAIN)/llc
 OBJDUMP	:= $(LLVM_TOOLCHAIN)/llvm-objdump
 
 override CFLAGS += -Xclang -disable-O0-optnone -mno-red-zone -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
-override CFLAGS += -O0 -Wall -mllvm -align-bytes
+override CFLAGS += -O0 -Wall -mllvm -align-bytes-to-four
 
 override OPT_FLAGS 	+= -name-string-literals -static-var-sections -live-values -insert-stackmaps
 


### PR DESCRIPTION
Fix flag in makefile causing data layout mismatch due to different
alignment chosen for i8 integers (i.e., single bytes) between Clang
frontend and LLVM backend.
This seems to have been a relic from a previous iteration of the flag
option.

Fixes #89