### PR TITLE
Remove unnecessary flag for disabling lsr.

### DIFF
--- a/layout/common/common.mk
+++ b/layout/common/common.mk
@@ -29,7 +29,7 @@ override LLC_FLAGS	+= -relocation-model=pic --trap-unreachable -optimize-regallo
 # Callsite-related
 override LLC_FLAGS  += -disable-block-align --mc-relax-all
 # Custom
-override LLC_FLAGS  += -disable-x86-frame-obj-order -aarch64-csr-alignment=8 -disable-lsr-solver -align-bytes-to-four -reg-scavenging-slot -enable-misched=false
+override LLC_FLAGS  += -disable-x86-frame-obj-order -aarch64-csr-alignment=8 -align-bytes-to-four -reg-scavenging-slot -enable-misched=false
 
 override LLC_FLAGS_ARM64 += -mattr=+disable-hoist-in-lowering,+disable-fp-imm-materialize,-avoid-f128
 override LLC_FLAGS_X86 += -mattr=+aarch64-sized-imm,-multiply-with-imm,-non-zero-imm-to-mem,+force-vector-mem-op,+aarch64-constant-cost-model,+simple-reg-offset-addr,+avoid-opt-mul-1 -no-x86-call-frame-opt


### PR DESCRIPTION
This flag is unnecessary now (was one of the Master's student flags), and we might save some performance also.