### PR TITLE
Use make flag to control unified layout compiler flags

### DIFF
--- a/layout/common/common.mk
+++ b/layout/common/common.mk
@@ -22,6 +22,8 @@ X86_64_OBJDUMP := x86_64-linux-gnu-objdump
 
 override CFLAGS += -Xclang -disable-O0-optnone -mno-red-zone -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
 override CFLAGS += -O0 -Wall
+
+ifndef UNMODIFIED
 override CFLAGS += -mllvm -align-bytes-to-four
 
 override OPT_FLAGS	+= -name-string-literals -static-var-sections -live-values -insert-stackmaps
@@ -35,6 +37,7 @@ override LLC_FLAGS  += -disable-x86-frame-obj-order -aarch64-csr-alignment=8 -al
 
 override LLC_FLAGS_ARM64 += -mattr=+disable-hoist-in-lowering,+disable-fp-imm-materialize,-avoid-f128,+avoid-wide-mul-add
 override LLC_FLAGS_X86 += -mattr=+aarch64-sized-imm,-multiply-with-imm,-non-zero-imm-to-mem,+force-vector-mem-op,+aarch64-constant-cost-model,+simple-reg-offset-addr,+avoid-opt-mul-1 -no-x86-call-frame-opt
+endif
 
 LLC_PASSES_TO_DEBUG	:= isel regalloc stackmaps stacktransform
 

--- a/layout/common/sterope-unmodified.defs.mk
+++ b/layout/common/sterope-unmodified.defs.mk
@@ -18,3 +18,5 @@ MCA	?= $(LLVM_TOOLCHAIN)/llvm-mca
 ARM64_CPU	?= thunderx2t99
 X86_64_CPU	?= btver2
 MCA_RESULT_DIR	?= ../mca-results/reg-pressure-O0
+
+UNMODIFIED := 1


### PR DESCRIPTION
This PR:

- Adds the use of `UNMODIFIED` makefile definition to disable all UnASL-related modifications in the LLVM/Clang compiler toolchain controlled by flags. The flag can be added and turned on to makefile definitions file that invoke an unmodified compiler toolchain.

*Limitation*: In order for compilation to occur correctly, this is only supported for the `init` make target. A future patch is needed to also disable the UnASL-related makefile rules.