### PR TITLE
Disable conditionally vDSO-served syscalls for migration builds

### DIFF
--- a/layout/npb3.3-ser-c-flat/cg/wtime.c
+++ b/layout/npb3.3-ser-c-flat/cg/wtime.c
@@ -1,16 +1,22 @@
 #include "wtime.h"
+#ifndef UNASL_MIGRATION
 #include <time.h>
 #ifndef DOS
 #include <sys/time.h>
 #endif
+#endif /* UNASL_MIGRATION */
 
 void wtime(double *t)
 {
+#ifdef UNASL_MIGRATION
+  *t = 0;
+#else
   static int sec = -1;
   struct timeval tv;
   gettimeofday(&tv, (void *)0);
   if (sec < 0) sec = tv.tv_sec;
   *t = (tv.tv_sec - sec) + 1.0e-6*tv.tv_usec;
+#endif /* UNASL_MIGRATION */
 }
 
-    
+

--- a/layout/npb3.3-ser-c-flat/ep/wtime.c
+++ b/layout/npb3.3-ser-c-flat/ep/wtime.c
@@ -1,16 +1,22 @@
 #include "wtime.h"
+#ifndef UNASL_MIGRATION
 #include <time.h>
 #ifndef DOS
 #include <sys/time.h>
 #endif
+#endif /* UNASL_MIGRATION */
 
 void wtime(double *t)
 {
+#ifdef UNASL_MIGRATION
+  *t = 0;
+#else
   static int sec = -1;
   struct timeval tv;
   gettimeofday(&tv, (void *)0);
   if (sec < 0) sec = tv.tv_sec;
   *t = (tv.tv_sec - sec) + 1.0e-6*tv.tv_usec;
+#endif /* UNASL_MIGRATION */
 }
 
-    
+

--- a/layout/npb3.3-ser-c-flat/ft/wtime.c
+++ b/layout/npb3.3-ser-c-flat/ft/wtime.c
@@ -1,16 +1,22 @@
 #include "wtime.h"
+#ifndef UNASL_MIGRATION
 #include <time.h>
 #ifndef DOS
 #include <sys/time.h>
 #endif
+#endif /* UNASL_MIGRATION */
 
 void wtime(double *t)
 {
+#ifdef UNASL_MIGRATION
+  *t = 0;
+#else
   static int sec = -1;
   struct timeval tv;
   gettimeofday(&tv, (void *)0);
   if (sec < 0) sec = tv.tv_sec;
   *t = (tv.tv_sec - sec) + 1.0e-6*tv.tv_usec;
+#endif /* UNASL_MIGRATION */
 }
 
-    
+

--- a/layout/npb3.3-ser-c-flat/is/wtime.c
+++ b/layout/npb3.3-ser-c-flat/is/wtime.c
@@ -1,16 +1,22 @@
 #include "wtime.h"
+#ifndef UNASL_MIGRATION
 #include <time.h>
 #ifndef DOS
 #include <sys/time.h>
 #endif
+#endif /* UNASL_MIGRATION */
 
 void wtime(double *t)
 {
+#ifdef UNASL_MIGRATION
+  *t = 0;
+#else
   static int sec = -1;
   struct timeval tv;
   gettimeofday(&tv, (void *)0);
   if (sec < 0) sec = tv.tv_sec;
   *t = (tv.tv_sec - sec) + 1.0e-6*tv.tv_usec;
+#endif /* UNASL_MIGRATION */
 }
 
-    
+


### PR DESCRIPTION
This PR:

- Disables vDSO-served syscalls for migration builds when the relevant preprocessor macro is also defined.  
  This allows for the transfer of the memory pages where the `.data` section is mapped from AArch64 to X86_64 without any conversion.

Addresses #202