### PR TITLE
Fix different number of callsites for lu, sp, and ua.

### DIFF
--- a/layout/npb3.3-ser-c-flat/lu/domain.c
+++ b/layout/npb3.3-ser-c-flat/lu/domain.c
@@ -52,7 +52,7 @@ void domain()
            "     ADJUST PROBLEM SIZE OR NUMBER OF PROCESSORS\n"
            "     SO THAT NX, NY AND NZ ARE GREATER THAN OR EQUAL\n"
            "     TO 4 THEY ARE CURRENTLY%3d%3d%3d\n", nx, ny, nz);
-    exit(EXIT_FAILURE);
+    /*exit(EXIT_FAILURE);*/ /* TODO temporary handling for Unifico */
   }
 
   if ( ( nx > ISIZ1 ) || ( ny > ISIZ2 ) || ( nz > ISIZ3 ) ) {
@@ -61,7 +61,7 @@ void domain()
            "     SO THAT NX, NY AND NZ ARE LESS THAN OR EQUAL TO \n"
            "     ISIZ1, ISIZ2 AND ISIZ3 RESPECTIVELY.  THEY ARE\n"
            "     CURRENTLYi%4d%4d%4d\n", nx, ny, nz);
-    exit(EXIT_FAILURE);
+    /*exit(EXIT_FAILURE);*/ /* TODO temporary handling for Unifico */
   }
 
   //---------------------------------------------------------------------

--- a/layout/npb3.3-ser-c-flat/lu/read_input.c
+++ b/layout/npb3.3-ser-c-flat/lu/read_input.c
@@ -106,14 +106,14 @@ void read_input()
   if ( ( nx0 < 4 ) || ( ny0 < 4 ) || ( nz0 < 4 ) ) {
     printf("     PROBLEM SIZE IS TOO SMALL - \n"
            "     SET EACH OF NX, NY AND NZ AT LEAST EQUAL TO 5\n");
-    exit(EXIT_FAILURE);
+    /*exit(EXIT_FAILURE);*/ /* TODO temporary handling for Unifico */
   }
 
   if ( ( nx0 > ISIZ1 ) || ( ny0 > ISIZ2 ) || ( nz0 > ISIZ3 ) ) {
     printf("     PROBLEM SIZE IS TOO LARGE - \n"
            "     NX, NY AND NZ SHOULD BE EQUAL TO \n"
            "     ISIZ1, ISIZ2 AND ISIZ3 RESPECTIVELY\n");
-    exit(EXIT_FAILURE);
+    /*exit(EXIT_FAILURE);*/ /* TODO temporary handling for Unifico */
   }
 
   printf(" Size: %4dx%4dx%4d\n", nx0, ny0, nz0);

--- a/layout/npb3.3-ser-c-flat/sp/set_constants.c
+++ b/layout/npb3.3-ser-c-flat/sp/set_constants.c
@@ -112,7 +112,8 @@ void set_constants()
   c4 = 1.0;
   c5 = 1.4;
 
-  bt = sqrt(0.5);
+  double temp_d = 0.5;
+  bt = sqrt(temp_d); /* TODO temporary handling for Unifico */
 
   dnxm1 = 1.0 / (double)(grid_points[0]-1);
   dnym1 = 1.0 / (double)(grid_points[1]-1);

--- a/layout/npb3.3-ser-c-flat/ua/precond.c
+++ b/layout/npb3.3-ser-c-flat/ua/precond.c
@@ -731,7 +731,8 @@ static void com_dpc(int iside, int iel, int enumber, int n, int isize)
     anc0 = 0.0;
   } else {
     // MUST NOT reachable!!
-    assert(0);
+    // assert(0);
+    printf("Unreachable\n"); /* TODO temporary handling for Unifico */
     anc1 = 0.0;
     ac = 0.0;
     anc2 = 0.0;


### PR DESCRIPTION
For lu, we comment out `exit(FAILURE)`.

For sp, we modify the call to `sqrt(0.5)` which is generated differently
in x86, i.e., there is no branch to check for overflow.

For ua, we comment out `assert(0)`.

Closes #205.