### PR TITLE
Added initial .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+BreakBeforeBraces: Stroustrup

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,7 @@ repos:
     rev: 22.6.0
     hooks:
       - id: black
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v14.0.6
+    hooks:
+      - id: clang-format


### PR DESCRIPTION
Also added it to the pre-commit hooks.

I'm not very religious with the clang-format settings. LLVM's works just fine.

I only changed the indentation size, because I find only 2 spaces to be too "dense". I also like a newline after a function's brace.

I'm adding this to the pre-commit hooks, hopefully that should do the trick.