### PR TITLE
Add option to sort data in plot_barchart

### DIFF
--- a/npb/plots/plot_barchart.py
+++ b/npb/plots/plot_barchart.py
@@ -42,7 +42,7 @@ def plot(datafile, stylefile, configfile, interactive=False, sort=False):
     df = pd.read_csv(datafile, **cfg_df)
 
     if sort:
-        df.sort_index(inplace=True)
+        df.sort_index(inplace=True, key=lambda col: col.str.swapcase())
 
     _, axis = plt.subplots()
 


### PR DESCRIPTION
The index of the DataFrame that is plotted is usually the name of the benchmarks. It's useful to have the option to sort them alphabetically, so that different unordered data sheets can be plotted in the same fashion. Otherwise, we have to impose an order ourselves in the data sheet.

This is added as an option in case we actually want to show a different order than the alphabetical.