### PR TITLE
[layout] Add separate optimization level flag OPT_LEVEL

### DIFF
--- a/layout/common/common.mk
+++ b/layout/common/common.mk
@@ -21,8 +21,9 @@ LLC		:= $(LLVM_TOOLCHAIN)/llc
 OBJDUMP	:= $(LLVM_TOOLCHAIN)/llvm-objdump
 X86_64_OBJDUMP := x86_64-linux-gnu-objdump
 
+OPT_LEVEL ?= -O0
+override CFLAGS += $(OPT_LEVEL) -Wall
 override CFLAGS += -Xclang -disable-O0-optnone -mno-red-zone -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
-override CFLAGS += -O0 -Wall
 
 ifndef UNMODIFIED
 override CFLAGS += -mllvm -align-bytes-to-four


### PR DESCRIPTION
We want to be able to run checks both for -O0 and for -O1, so it is helpful to add a separate Makefile variable to configure this from the command line or other calling tools.

Invoke with:
`make stackmaps-check OPT_LEVEL=-O1`
The default is -O0.