### PR TITLE
[stackmaps][check] Check explicitly for differences in live-out regs

### DIFF
--- a/stack-metadata/utils/check_stackmaps.c
+++ b/stack-metadata/utils/check_stackmaps.c
@@ -310,6 +310,37 @@ ret_t check_stackmaps(bin *a, stack_map_section *sm_a, size_t num_sm_a, bin *b,
                         l++;
                 }
 
+                /*
+                 * Check the number of live-out registers.
+                 */
+                num_a = sm_a[i].call_sites[j].num_live_outs;
+                num_b = sm_b[i].call_sites[j].num_live_outs;
+
+                if (num_a != num_b) {
+                    snprintf(
+                        buf, BUF_SIZE,
+                        "%s: callsite %lu has "
+                        "different number of live out registers (%u vs %u)",
+                        sym_b_name, sm_b[i].call_sites[j].id, num_a, num_b);
+                    warn(buf);
+                    ret = DIFFERENT_STACK_LAYOUT;
+                }
+
+                for (k = 0, l = 0; k < num_a && l < num_b; k++, l++) {
+                    flag_a = sm_a[i].call_sites[j].live_outs[k].size;
+                    flag_b = sm_b[i].call_sites[j].live_outs[l].size;
+                    if (flag_a != flag_b) {
+                        snprintf(buf, BUF_SIZE,
+                                 "%s, callsite %lu: live out registers"
+                                 "%lu/%lu have "
+                                 "different size (%d vs. %d)",
+                                 sym_a_name, sm_a[i].call_sites[j].id, k, l,
+                                 flag_a, flag_b);
+                        warn(buf);
+                        ret = DIFFERENT_STACK_LAYOUT;
+                    }
+                }
+
                 num_a = sm_a[i].call_sites[j].num_arch_live;
                 num_b = sm_b[i].call_sites[j].num_arch_live;
 

--- a/stack-metadata/utils/dump_llvm_stackmap.c
+++ b/stack-metadata/utils/dump_llvm_stackmap.c
@@ -200,7 +200,7 @@ static inline bool dump_call_site(call_site_record *cs, uint64_t func)
             return false;
 
     for (i = 0; i < cs->num_live_outs; i++)
-        printf("    Live-out: register %u (size=%u bytes)",
+        printf("    Live-out: register %u (size=%u bytes)\n",
                cs->live_outs[i].regnum, cs->live_outs[i].size);
 
     for (i = 0; i < cs->num_arch_live; i++)


### PR DESCRIPTION
Currently, only compares their number and size.

The previous machinery checked for `live_value` and `arch_live_value`, not for `live_out_record`, because we hadn't encountered it so far.